### PR TITLE
Upgrade various gha steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4.1.1
 
-    - uses: actions/setup-go@v2
+    - uses: actions/setup-go@v5
       with:
         go-version: '>=1.21.0'
 
@@ -31,7 +31,7 @@ jobs:
       uses: jandelgado/gcov2lcov-action@v1.0.9
 
     - name: Coveralls
-      uses: coverallsapp/github-action@1.1.3
+      uses: coverallsapp/github-action@v2.2.3
       with:
         github-token: ${{ secrets.github_token }}
         path-to-lcov: coverage.lcov
@@ -47,7 +47,7 @@ jobs:
         golangci-lint run --skip-files='.*_test.go'
 
     - name: Archive stuff
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4.0.0
       with:
         name: build-artefacts
         path: |
@@ -65,7 +65,7 @@ jobs:
         fetch-depth: 0
 
     - name: Download artefacts
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4.1.0
       with:
         name: build-artefacts
 
@@ -84,15 +84,15 @@ jobs:
     runs-on: ubuntu-latest
     if: contains(github.ref, 'refs/tags')
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4.1.1
 
     - name: Download artefacts
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4.1.0
       with:
         name: build-artefacts
 
     - name: Generate SBOM
-      uses: CycloneDX/gh-gomod-generate-sbom@v1
+      uses: CycloneDX/gh-gomod-generate-sbom@v2
       with:
         version: v1
         args: mod -licenses -json -output bom.json

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Vulnerabilities](https://sonarcloud.io/api/project_badges/measure?project=jspc_littleauth&metric=vulnerabilities)](https://sonarcloud.io/summary/new_code?id=jspc_littleauth)
 [![Bugs](https://sonarcloud.io/api/project_badges/measure?project=jspc_littleauth&metric=bugs)](https://sonarcloud.io/summary/new_code?id=jspc_littleauth)
 [![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=jspc_littleauth&metric=security_rating)](https://sonarcloud.io/summary/new_code?id=jspc_littleauth)
+[![Coverage Status](https://coveralls.io/repos/github/jspc/littleauth/badge.svg?branch=main)](https://coveralls.io/github/jspc/littleauth?branch=main)
 
 # littleauth
 


### PR DESCRIPTION
Avoid messages like:

```
The following actions uses node12 which is deprecated and will be forced to run on node16: actions/setup-go@v2, coverallsapp/github-action@1.1.3. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/
```